### PR TITLE
fix the problem about phase missing in rearrangePhasesAndCodes()

### DIFF
--- a/src/gnss/gnss_common.cpp
+++ b/src/gnss/gnss_common.cpp
@@ -297,6 +297,8 @@ void rearrangePhasesAndCodes(GnssMeasurement& measurement, bool accept_coarse)
       std::pair<int, Observation> arranged_observation;
       int code = it->first;
       Observation observation = it->second;
+      // exclude observations that only have pseudorange for ppp and rtk
+      if (observation.phaserange==0.0) continue;
       int phase_id = getPhaseID(system, code);
       int default_code = 0;
 #define MAP(S, P, C) \


### PR DESCRIPTION
When multiple code types coexist within a frequency band, if a code type lacking carrier phase observations is prioritized during the allocation process in rearrangePhasesAndCodes(), it may result in resource occupation. This subsequently prevents the insertion of other code types possessing carrier phase observations, ultimately leading to the absence of an entire frequency band in the final positioning solution.